### PR TITLE
fixed lookback window validation

### DIFF
--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -406,9 +406,11 @@ class Stream():
     def lookback_window(self):
         # Get lookback window from config and verify value
         lookback_window = self.config.get('lookback_window') or '0'
-        if not lookback_window.isdigit():
+        try:
+            return int(lookback_window)
+        except:
             raise TypeError("lookback_window '{}' is not numeric. Check your configuration".format(lookback_window))
-        return int(lookback_window)
+        
 
 class LazyAggregationStream(Stream):
     def send_request_get_results(self, req):


### PR DESCRIPTION
# Description of change
Changed validation of lookback_window configuration to use try/except instead of `str.isdigit()` to prevent validation from failing if `lookback_window` is already an `int`

`str.isdigit()` can currently fail if the type of `config.get('lookback_window')` is not a string, giving the error `'int' object has no attribute 'isdigit'`.

This means that if the `config` object passed to `Stream.__init__()` has already converted `lookback_window` to an `int` or other numeric type, the validation will fail even though it shouldn't.

This change corrects this behavior; validation will only fail if `int(lookback_window)` fails.

`int()` does not raise any exceptions besides `TypeError`, so this will not affect what exceptions the function can raise.

# Manual QA steps
 - 
 
# Risks
 -  
 
# Rollback steps
 - revert this branch